### PR TITLE
Update plugins to show parent, solution icons in search results

### DIFF
--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -281,7 +281,7 @@ export class DashboardPlugin
       id: DashboardConstants.DASHBOARDS_ID,
       title: 'Dashboard',
       order: 2500,
-      euiIconType: 'dashboardApp',
+      euiIconType: 'logoKibana',
       defaultPath: `#${DashboardConstants.LANDING_PAGE_PATH}`,
       updater$: this.appStateUpdater,
       category: DEFAULT_APP_CATEGORIES.kibana,

--- a/src/plugins/dev_tools/public/plugin.ts
+++ b/src/plugins/dev_tools/public/plugin.ts
@@ -60,7 +60,7 @@ export class DevToolsPlugin implements Plugin<DevToolsSetup, void> {
         defaultMessage: 'Dev Tools',
       }),
       updater$: this.appStateUpdater,
-      euiIconType: 'devToolsApp',
+      euiIconType: 'logoElastic',
       order: 9010,
       category: DEFAULT_APP_CATEGORIES.management,
       mount: async (params: AppMountParameters) => {

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -237,7 +237,7 @@ export class DiscoverPlugin
       title: 'Discover',
       updater$: this.appStateUpdater.asObservable(),
       order: 1000,
-      euiIconType: 'discoverApp',
+      euiIconType: 'logoKibana',
       defaultPath: '#/',
       category: DEFAULT_APP_CATEGORIES.kibana,
       mount: async (params: AppMountParameters) => {

--- a/src/plugins/management/public/plugin.ts
+++ b/src/plugins/management/public/plugin.ts
@@ -66,7 +66,7 @@ export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart
         defaultMessage: 'Stack Management',
       }),
       order: 9040,
-      euiIconType: 'managementApp',
+      euiIconType: 'logoElastic',
       category: DEFAULT_APP_CATEGORIES.management,
       async mount(params: AppMountParameters) {
         const { renderApp } = await import('./application');

--- a/src/plugins/newsfeed/public/components/newsfeed_header_nav_button.tsx
+++ b/src/plugins/newsfeed/public/components/newsfeed_header_nav_button.tsx
@@ -68,7 +68,7 @@ export const NewsfeedNavButton = ({ apiFetchResult }: Props) => {
           aria-label="Newsfeed menu"
           onClick={showFlyout}
         >
-          <EuiIcon type="email" size="m" />
+          <EuiIcon type="cheer" size="m" />
           {showBadge ? (
             <EuiNotificationBadge className="euiHeaderNotification" data-test-subj="showBadgeNews">
               &#9642;

--- a/src/plugins/timelion/public/plugin.ts
+++ b/src/plugins/timelion/public/plugin.ts
@@ -91,7 +91,7 @@ export class TimelionPlugin implements Plugin<void, void> {
       title: 'Timelion',
       order: 8000,
       defaultPath: '#/',
-      euiIconType: 'timelionApp',
+      euiIconType: 'logoKibana',
       category: DEFAULT_APP_CATEGORIES.kibana,
       updater$: this.appStateUpdater.asObservable(),
       mount: async (params: AppMountParameters) => {

--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -142,7 +142,7 @@ export class VisualizePlugin
       id: 'visualize',
       title: 'Visualize',
       order: 8000,
-      euiIconType: 'visualizeApp',
+      euiIconType: 'logoKibana',
       defaultPath: '#/',
       category: DEFAULT_APP_CATEGORIES.kibana,
       updater$: this.appStateUpdater.asObservable(),

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -101,7 +101,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       id: 'apm',
       title: 'APM',
       order: 8300,
-      euiIconType: 'apmApp',
+      euiIconType: 'logoObservability',
       appRoute: '/app/apm',
       icon: 'plugins/apm/public/icon.svg',
       category: DEFAULT_APP_CATEGORIES.observability,
@@ -121,6 +121,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       id: 'csm',
       title: 'Client Side Monitoring',
       order: 8500,
+      euiIconType: 'logoObservability',
       category: DEFAULT_APP_CATEGORIES.observability,
 
       async mount(params: AppMountParameters<unknown>) {

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -88,7 +88,7 @@ export class CanvasPlugin
       category: DEFAULT_APP_CATEGORIES.kibana,
       id: 'canvas',
       title: 'Canvas',
-      euiIconType: 'canvasApp',
+      euiIconType: 'logoKibana',
       order: 3000,
       updater$: this.appUpdater,
       mount: async (params: AppMountParameters) => {

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -12,6 +12,7 @@ export const ENTERPRISE_SEARCH_PLUGIN = {
     defaultMessage: 'Enterprise Search',
   }),
   URL: '/app/enterprise_search',
+  LOGO: 'logoEnterpriseSearch',
 };
 
 export const APP_SEARCH_PLUGIN = {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -20,7 +20,11 @@ import {
 import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
 import { LicensingPluginSetup } from '../../licensing/public';
 
-import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../common/constants';
+import {
+  ENTERPRISE_SEARCH_PLUGIN,
+  APP_SEARCH_PLUGIN,
+  WORKPLACE_SEARCH_PLUGIN,
+} from '../common/constants';
 import {
   getPublicUrl,
   ExternalUrl,
@@ -55,6 +59,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     core.application.register({
       id: APP_SEARCH_PLUGIN.ID,
       title: APP_SEARCH_PLUGIN.NAME,
+      euiIconType: ENTERPRISE_SEARCH_PLUGIN.LOGO,
       appRoute: APP_SEARCH_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
@@ -74,6 +79,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     core.application.register({
       id: WORKPLACE_SEARCH_PLUGIN.ID,
       title: WORKPLACE_SEARCH_PLUGIN.NAME,
+      euiIconType: ENTERPRISE_SEARCH_PLUGIN.LOGO,
       appRoute: WORKPLACE_SEARCH_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {

--- a/x-pack/plugins/graph/public/plugin.ts
+++ b/x-pack/plugins/graph/public/plugin.ts
@@ -74,7 +74,7 @@ export class GraphPlugin
       title: 'Graph',
       order: 6000,
       appRoute: '/app/graph',
-      euiIconType: 'graphApp',
+      euiIconType: 'logoKibana',
       category: DEFAULT_APP_CATEGORIES.kibana,
       mount: async (params: AppMountParameters) => {
         const [coreStart, pluginsStart] = await core.getStartServices();

--- a/x-pack/plugins/infra/public/plugin.ts
+++ b/x-pack/plugins/infra/public/plugin.ts
@@ -50,7 +50,7 @@ export class Plugin implements InfraClientPluginClass {
       title: i18n.translate('xpack.infra.logs.pluginTitle', {
         defaultMessage: 'Logs',
       }),
-      euiIconType: 'logsApp',
+      euiIconType: 'logoObservability',
       order: 8100,
       appRoute: '/app/logs',
       category: DEFAULT_APP_CATEGORIES.observability,
@@ -68,7 +68,7 @@ export class Plugin implements InfraClientPluginClass {
       title: i18n.translate('xpack.infra.metrics.pluginTitle', {
         defaultMessage: 'Metrics',
       }),
-      euiIconType: 'metricsApp',
+      euiIconType: 'logoObservability',
       order: 8200,
       appRoute: '/app/metrics',
       category: DEFAULT_APP_CATEGORIES.observability,

--- a/x-pack/plugins/ingest_manager/public/plugin.ts
+++ b/x-pack/plugins/ingest_manager/public/plugin.ts
@@ -73,7 +73,7 @@ export class IngestManagerPlugin
       category: DEFAULT_APP_CATEGORIES.management,
       title: i18n.translate('xpack.ingestManager.appTitle', { defaultMessage: 'Ingest Manager' }),
       order: 9020,
-      euiIconType: 'savedObjectsApp',
+      euiIconType: 'logoElastic',
       async mount(params: AppMountParameters) {
         const [coreStart, startDeps] = (await core.getStartServices()) as [
           CoreStart,

--- a/x-pack/plugins/maps/common/constants.ts
+++ b/x-pack/plugins/maps/common/constants.ts
@@ -26,6 +26,7 @@ export const EMS_TILES_VECTOR_TILE_PATH = 'vector/tile';
 export const MAP_SAVED_OBJECT_TYPE = 'map';
 export const APP_ID = 'maps';
 export const APP_ICON = 'gisApp';
+export const APP_ICON_SOLUTION = 'logoKibana';
 export const INITIAL_LAYERS_KEY = 'initialLayers';
 
 export const MAPS_APP_PATH = `app/${APP_ID}`;

--- a/x-pack/plugins/maps/public/plugin.ts
+++ b/x-pack/plugins/maps/public/plugin.ts
@@ -30,7 +30,7 @@ import { featureCatalogueEntry } from './feature_catalogue_entry';
 import { getMapsVisTypeAlias } from './maps_vis_type_alias';
 import { HomePublicPluginSetup } from '../../../../src/plugins/home/public';
 import { VisualizationsSetup } from '../../../../src/plugins/visualizations/public';
-import { APP_ICON, APP_ID, MAP_SAVED_OBJECT_TYPE } from '../common/constants';
+import { APP_ICON_SOLUTION, APP_ID, MAP_SAVED_OBJECT_TYPE } from '../common/constants';
 import { VISUALIZE_GEO_FIELD_TRIGGER } from '../../../../src/plugins/ui_actions/public';
 import { createMapsUrlGenerator } from './url_generator';
 import { visualizeGeoFieldAction } from './trigger_actions/visualize_geo_field_action';
@@ -119,7 +119,7 @@ export class MapsPlugin
       title: getAppTitle(),
       order: 4000,
       icon: `plugins/${APP_ID}/icon.svg`,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.kibana,
       // @ts-expect-error
       async mount(context, params) {

--- a/x-pack/plugins/ml/common/constants/app.ts
+++ b/x-pack/plugins/ml/common/constants/app.ts
@@ -6,3 +6,4 @@
 
 export const PLUGIN_ID = 'ml';
 export const PLUGIN_ICON = 'machineLearningApp';
+export const PLUGIN_ICON_SOLUTION = 'logoKibana';

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -29,7 +29,7 @@ import { LicensingPluginSetup } from '../../licensing/public';
 import { registerManagementSection } from './application/management';
 import { LicenseManagementUIPluginSetup } from '../../license_management/public';
 import { setDependencyCache } from './application/util/dependency_cache';
-import { PLUGIN_ICON, PLUGIN_ID } from '../common/constants/app';
+import { PLUGIN_ICON_SOLUTION, PLUGIN_ID } from '../common/constants/app';
 import { registerFeature } from './register_feature';
 import { UiActionsSetup, UiActionsStart } from '../../../../src/plugins/ui_actions/public';
 import { registerMlUiActions } from './ui_actions';
@@ -72,7 +72,7 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
         defaultMessage: 'Machine Learning',
       }),
       order: 5000,
-      euiIconType: PLUGIN_ICON,
+      euiIconType: PLUGIN_ICON_SOLUTION,
       appRoute: '/app/ml',
       category: DEFAULT_APP_CATEGORIES.kibana,
       updater$: this.appUpdater,

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -28,6 +28,7 @@ export class Plugin implements PluginClass<ObservabilityPluginSetup, Observabili
       id: 'observability-overview',
       title: 'Overview',
       order: 8000,
+      euiIconType: 'logoObservability',
       appRoute: '/app/observability',
       category: DEFAULT_APP_CATEGORIES.observability,
 

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -8,6 +8,7 @@ export const APP_ID = 'securitySolution';
 export const SERVER_APP_ID = 'siem';
 export const APP_NAME = 'Security';
 export const APP_ICON = 'securityAnalyticsApp';
+export const APP_ICON_SOLUTION = 'logoSecurity';
 export const APP_PATH = `/app/security`;
 export const ADD_DATA_PATH = `/app/home#/tutorial_directory/security`;
 export const ADD_INDEX_PATH = `/app/management/kibana/indexPatterns/create`;

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -34,6 +34,7 @@ import {
 import {
   APP_ID,
   APP_ICON,
+  APP_ICON_SOLUTION,
   APP_DETECTIONS_PATH,
   APP_HOSTS_PATH,
   APP_OVERVIEW_PATH,
@@ -121,7 +122,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       id: `${APP_ID}:${SecurityPageName.overview}`,
       title: OVERVIEW,
       order: 9000,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.security,
       appRoute: APP_OVERVIEW_PATH,
       mount: async (params: AppMountParameters) => {
@@ -149,7 +150,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       id: `${APP_ID}:${SecurityPageName.detections}`,
       title: DETECTION_ENGINE,
       order: 9001,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.security,
       appRoute: APP_DETECTIONS_PATH,
       mount: async (params: AppMountParameters) => {
@@ -176,7 +177,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       id: `${APP_ID}:${SecurityPageName.hosts}`,
       title: HOSTS,
       order: 9002,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.security,
       appRoute: APP_HOSTS_PATH,
       mount: async (params: AppMountParameters) => {
@@ -203,7 +204,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       id: `${APP_ID}:${SecurityPageName.network}`,
       title: NETWORK,
       order: 9002,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.security,
       appRoute: APP_NETWORK_PATH,
       mount: async (params: AppMountParameters) => {
@@ -230,7 +231,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       id: `${APP_ID}:${SecurityPageName.timelines}`,
       title: TIMELINES,
       order: 9002,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.security,
       appRoute: APP_TIMELINES_PATH,
       mount: async (params: AppMountParameters) => {
@@ -257,7 +258,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       id: `${APP_ID}:${SecurityPageName.case}`,
       title: CASE,
       order: 9002,
-      euiIconType: APP_ICON,
+      euiIconType: APP_ICON_SOLUTION,
       category: DEFAULT_APP_CATEGORIES.security,
       appRoute: APP_CASES_PATH,
       mount: async (params: AppMountParameters) => {

--- a/x-pack/plugins/uptime/public/apps/plugin.ts
+++ b/x-pack/plugins/uptime/public/apps/plugin.ts
@@ -87,7 +87,7 @@ export class UptimePlugin
     core.application.register({
       appRoute: '/app/uptime#/',
       id: PLUGIN.ID,
-      euiIconType: 'uptimeApp',
+      euiIconType: 'logoObservability',
       order: 8400,
       title: PLUGIN.TITLE,
       category: DEFAULT_APP_CATEGORIES.observability,


### PR DESCRIPTION
The search results design specifies that solution (parent) icons are displayed alongside application results. Currently, plugins register an outlined app icon which we are moving away from. This PR changes the client side icons from the app version to the solution version.

There are other design tweaks coming to this layout (as seen in the second screenshot), so ignore the misalignment, but this demonstrates (approximately) where the solution logo will be shown:

#### This PR
<img width="660" alt="Screen Shot 2020-08-20 at 4 40 39 PM" src="https://user-images.githubusercontent.com/446285/90828598-e8e5c200-e303-11ea-9e79-8bc3e2adce5b.png">

#### + forthcoming design changes
<img width="666" alt="Screen Shot 2020-08-20 at 4 41 54 PM" src="https://user-images.githubusercontent.com/446285/90828766-2b0f0380-e304-11ea-936f-1d283ca45aa7.png">
