### PR TITLE
Design tweaks for badge list

### DIFF
--- a/x-pack/plugins/global_search_bar/public/components/search_bar.scss
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.scss
@@ -1,10 +1,17 @@
 .kbnSearchOption__tagsList {
-  display: inline;
+  display: inline-block; // Horizontally aligns the tag list to the 'Go to' badge when row is focused
+  line-height: $euiFontSizeM !important;
 
-  .euiBadge__text {
-    max-width: 100px;
-    text-overflow: ellipsis;
+  .kbnSearchOption__tagsListItem {
+    display: inline-block;
+    max-width: 80px;
+    margin-right: $euiSizeS;
   }
+}
+
+.euiSelectableListItem-isFocused .kbnSearchOption__tagsList {
+  margin-right: $euiSizeXS;
+  border-right: $euiBorderThin; // Adds divider between the tag list and 'Go to' badge
 }
 
 //TODO add these overrides to EUI so that search behaves the same globally

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -101,9 +101,11 @@ const resultToOption = (
       const { color, name, id: tagId } = getTag(tag)!;
 
       return (
-        <EuiBadge color={color} key={tagId}>
-          {name}
-        </EuiBadge>
+        <li className="kbnSearchOption__tagsListItem">
+          <EuiBadge color={color} key={tagId}>
+            {name}
+          </EuiBadge>
+        </li>
       );
     });
 


### PR DESCRIPTION
## Summary

- Rely on 'built in' truncation; setting a max-width will produce the desired ellipsis
- Add the divider between tag list and 'Go to' badge
- Wrap badges in `<li>`'s for semantics

We'll still need to limit the total number of badges (likely 3 max; show those that were search on first)